### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "runcommand/manifest",
     "description": "See what's going on inside of WordPress.",
+    "type": "wp-cli-package",
     "homepage": "https://runcommand.io/wp/manifest/",
     "license": "MIT",
     "authors": [],


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
